### PR TITLE
fix(wrapper): move cd up in compose wrappers

### DIFF
--- a/pullio.sh
+++ b/pullio.sh
@@ -5,7 +5,7 @@ DOCKER_BINARY="${DOCKER_BINARY:-$(which 'docker')}"
 CACHE_LOCATION=/tmp
 TAG=""
 DEBUG=""
-CURRENT_VERSION=0.0.5
+CURRENT_VERSION=0.0.6
 LATEST_VERSION=$(curl -fsSL "https://api.github.com/repos/hotio/pullio/releases" | jq -r .[0].tag_name)
 
 if ! docker compose version >/dev/null 2>&1; then

--- a/pullio.sh
+++ b/pullio.sh
@@ -39,6 +39,7 @@ echo "Current version: ${CURRENT_VERSION}"
 echo "Latest version: ${LATEST_VERSION}"
 
 compose_pull_wrapper() {
+    cd "$1" || exit 1
     if [[ -z ${COMPOSE_BINARY} ]]; then
         if [[ "${COMPOSE_V2}" == "1" ]]; then
             "${DOCKER_BINARY}" compose pull "$2"
@@ -46,7 +47,6 @@ compose_pull_wrapper() {
             "${DOCKER_BINARY}" run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$1:$1" -w="$1" linuxserver/docker-compose pull "$2"
         fi
     else
-        cd "$1" || exit 1
         if [[ "${COMPOSE_V2}" == "1" ]]; then
             "${DOCKER_BINARY}" compose pull "$2"
         else
@@ -56,6 +56,7 @@ compose_pull_wrapper() {
 }
 
 compose_up_wrapper() {
+    cd "$1" || exit 1
     if [[ -z ${COMPOSE_BINARY} ]]; then
         if [[ "${COMPOSE_V2}" == "1" ]]; then
             "${DOCKER_BINARY}" compose up -d --always-recreate-deps "$2"
@@ -63,7 +64,6 @@ compose_up_wrapper() {
             "${DOCKER_BINARY}" run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$1:$1" -w="$1" linuxserver/docker-compose up -d --always-recreate-deps "$2"
         fi
     else
-        cd "$1" || exit 1
         if [[ "${COMPOSE_V2}" == "1" ]]; then
             "${DOCKER_BINARY}" compose up -d --always-recreate-deps "$2"
         else


### PR DESCRIPTION
Move the `cd` into the compose directories to the top of the wrapper functions to account for multiple docker-compose.yml files in different directories.

Example:
```
.docker/
├── plex
│   ├── docker-compose.yml
├── qbittorrentvpn
│   ├── docker-compose.yml
└── tig
    └── docker-compose.yml
```

Running pullio from `.docker` results in this:
```
nuxen@nuxbox ~/.docker
$ pullio
Using docker compose V2
Running with "DEBUG=" and "TAG=".
Current version: 0.0.5
Latest version: 0.0.5
gluetun: Checking...
gluetun: Pulling image...
no configuration file provided: not found
gluetun: Pulling failed!
grafana: Checking...
grafana: Pulling image...
no configuration file provided: not found
grafana: Pulling failed!
influxdb: Checking...
influxdb: Pulling image...
no configuration file provided: not found
influxdb: Pulling failed!
plex: Checking...
plex: Pulling image...
no configuration file provided: not found
plex: Pulling failed!
qbittorrentvpn: Checking...
telegraf: Checking...
telegraf: Pulling image...
no configuration file provided: not found
telegraf: Pulling failed!
Pruning docker images...
Total reclaimed space: 0B
```